### PR TITLE
Fix Sarama backwards incompat bug

### DIFF
--- a/internal/kafka/client.go
+++ b/internal/kafka/client.go
@@ -8,6 +8,7 @@ import (
 func NewProducer(c *Config) (sarama.SyncProducer, error) {
 	config := sarama.NewConfig()
 	config.Producer.Return.Errors = true
+	config.Producer.Return.Successes = true
 	config.ClientID = uuid.NewV4().String()
 
 	// TLS


### PR DESCRIPTION
Fix backwards incompatibility issue caused by https://github.com/Shopify/sarama/issues/816.
Without this fix, `connect-kafka` fails with:
```
FATA[0000] kafka: invalid configuration (Producer.Return.Successes must be true to be used in a SyncProducer) 
```